### PR TITLE
WIP: ENH: Add clang-format lint GitHub Action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,20 @@
+name: clang-format lint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        # Source folder to check formatting
+        source: '.'
+        # Folder to exclude from formatting check
+        exclude: './Modules/ThirdParty'
+        # List of extensions to check
+        extensions: '.c,.h,.cxx,.hxx'
+        # Version of clang-format
+        clangFormatVersion: 8.0

--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -81,7 +81,7 @@ Expect_CopyAssignableToSelf(const T & value)
   T self(value);
 
   // Slight contortion to avoid self-assignment warning with 'self = self'.
-  const T& referenceToSelf = self;
+  const T & referenceToSelf = self;
   self = referenceToSelf;
 
   EXPECT_EQ(self, value);

--- a/Modules/Core/Common/test/itkImageIORegionGTest.cxx
+++ b/Modules/Core/Common/test/itkImageIORegionGTest.cxx
@@ -81,7 +81,7 @@ Expect_CopyAssignableToSelf(const T & value)
   T self(value);
 
   // Slight contortion to avoid self-assignment warning with 'self = self'.
-  const T & referenceToSelf = self;
+  const T& referenceToSelf = self;
   self = referenceToSelf;
 
   EXPECT_EQ(self, value);

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -97,16 +97,16 @@ public:
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Type of the pixel to use for intermediate results */
-  using RealOutputPixelType = typename NumericTraits< OutputPixelType >::RealType;
-  using RealOutputImageType = Image< OutputPixelType, ImageDimension >;
+  using RealOutputPixelType = typename NumericTraits<OutputPixelType>::RealType;
+  using RealOutputImageType = Image<OutputPixelType, ImageDimension>;
   using RealOutputPixelValueType = typename NumericTraits<RealOutputPixelType>::ValueType;
 
   /** Typedef to describe the boundary condition. */
-  using BoundaryConditionType = ImageBoundaryCondition< TInputImage >;
+  using BoundaryConditionType = ImageBoundaryCondition<TInputImage>;
   using InputBoundaryConditionPointerType = BoundaryConditionType *;
-  using InputDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< TInputImage >;
+  using InputDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<TInputImage>;
   using RealBoundaryConditionPointerType = ImageBoundaryCondition<RealOutputImageType> *;
-  using RealDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< RealOutputImageType >;
+  using RealDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<RealOutputImageType>;
 
   /** Typedef of double containers */
   using ArrayType = FixedArray<double, Self::ImageDimension>;
@@ -356,9 +356,8 @@ private:
   /** Boundary condition use for the intermediate filters */
   RealBoundaryConditionPointerType m_RealBoundaryCondition;
 
- /** Default boundary condition use for the intermediate filters */
+  /** Default boundary condition use for the intermediate filters */
   RealDefaultBoundaryConditionType m_RealDefaultBoundaryCondition;
-
 };
 } // end namespace itk
 

--- a/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
+++ b/Modules/Filtering/Smoothing/include/itkDiscreteGaussianImageFilter.h
@@ -97,16 +97,16 @@ public:
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Type of the pixel to use for intermediate results */
-  using RealOutputPixelType = typename NumericTraits<OutputPixelType>::RealType;
-  using RealOutputImageType = Image<OutputPixelType, ImageDimension>;
+  using RealOutputPixelType = typename NumericTraits< OutputPixelType >::RealType;
+  using RealOutputImageType = Image< OutputPixelType, ImageDimension >;
   using RealOutputPixelValueType = typename NumericTraits<RealOutputPixelType>::ValueType;
 
   /** Typedef to describe the boundary condition. */
-  using BoundaryConditionType = ImageBoundaryCondition<TInputImage>;
+  using BoundaryConditionType = ImageBoundaryCondition< TInputImage >;
   using InputBoundaryConditionPointerType = BoundaryConditionType *;
-  using InputDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<TInputImage>;
+  using InputDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< TInputImage >;
   using RealBoundaryConditionPointerType = ImageBoundaryCondition<RealOutputImageType> *;
-  using RealDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<RealOutputImageType>;
+  using RealDefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition< RealOutputImageType >;
 
   /** Typedef of double containers */
   using ArrayType = FixedArray<double, Self::ImageDimension>;
@@ -356,8 +356,9 @@ private:
   /** Boundary condition use for the intermediate filters */
   RealBoundaryConditionPointerType m_RealBoundaryCondition;
 
-  /** Default boundary condition use for the intermediate filters */
+ /** Default boundary condition use for the intermediate filters */
   RealDefaultBoundaryConditionType m_RealDefaultBoundaryCondition;
+
 };
 } // end namespace itk
 

--- a/Utilities/Maintenance/clang-format.bash
+++ b/Utilities/Maintenance/clang-format.bash
@@ -82,6 +82,7 @@ test "$#" = 0 || die "$usage"
 # Find a default tool.
 tools='
   clang-format-8.0.0
+  clang-format-8
   clang-format
 '
 if test "x$clang_format" = "x"; then


### PR DESCRIPTION
Check whether the code has style issues as detected by clang-format.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
<!-- Delete either [X] or :no_entry_sign: to indicate if the statement is true or false. -->
- [X] :no_entry_sign: [Makes breaking changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#breaking-changes)
- [X] :no_entry_sign: [Makes design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md#design-changes)
- [X] :no_entry_sign: Adds the License notice to new files.
- [X] :no_entry_sign: Adds Python wrapping.
- [X] :no_entry_sign: Adds tests and baseline comparison (quantitative).
- [X] :no_entry_sign: [Adds test data](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/UploadBinaryData.md).
- [X] :no_entry_sign: Adds Examples to [ITKExamples](https://github.com/InsightSoftwareConsortium/ITKExamples)
- [X] :no_entry_sign: Adds Documentation.

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
