### PR TITLE
Address Variable Length Vector wrapping warnings (vibe-kanban)

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -546,12 +546,13 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
       )
 
       if(MSVC)
-        # Disables 'conversion from 'type1' to 'type2', possible loss of data warnings
+        # /wd4244: Disables 'conversion from 'type1' to 'type2', possible loss of data warnings
+        # /wd4996: Disables deprecated declaration warnings in generated wrapper code
         set_target_properties(
           ${lib}
           PROPERTIES
             COMPILE_FLAGS
-              "/wd4244"
+              "/wd4244 /wd4996"
         )
       endif()
     else()


### PR DESCRIPTION
Address:

2026-03-05T10:46:00.8055367Z D:\\a\\1\\s-build\\Wrapping\\Modules\\ITKCommon\\itkVariableLengthVectorPython.cpp(5150): warning C4996: 'itk::VariableLengthVector<std::complex<float>>::AllocateElements': Please consider calling \`std::make\_unique<TValue[]>(size)\` instead.
2026-03-05T10:46:01.2092615Z D:\\a\\1\\s-build\\Wrapping\\Modules\\ITKCommon\\itkVariableLengthVectorPython.cpp(7765): warning C4996: 'itk::VariableLengthVector<double>::AllocateElements': Please consider calling \`std::make\_unique<TValue[]>(size)\` instead.
2026-03-05T10:46:01.5126044Z D:\\a\\1\\s-build\\Wrapping\\Modules\\ITKCommon\\itkVariableLengthVectorPython.cpp(10633): warning C4996: 'itk::VariableLengthVector<float>::AllocateElements': Please consider calling \`std::make\_unique<TValue[]>(size)\` instead.
2026-03-05T10:46:01.6450308Z D:\\a\\1\\s-build\\Wrapping\\Modules\\ITKCommon\\itkVariableLengthVectorPython.cpp(13501): warning C4996: 'itk::VariableLengthVector<short>::AllocateElements': Please consider calling \`std::make\_unique<TValue[]>(size)\` instead.
2026-03-05T10:46:01.7074827Z D:\\a\\1\\s-build\\Wrapping\\Modules\\ITKCommon\\itkVariableLengthVectorPython.cpp(16369): warning C4996: 'itk::VariableLengthVector<unsigned char>::AllocateElements': Please consider calling \`std::make\_unique<TValue[]>(size)\` instead.